### PR TITLE
Appveyor allowfailures

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -37,15 +37,16 @@ install:
   - "curl https://raw.githubusercontent.com/chemeris/msinttypes/master/stdint.h -o skimage/external/tifffile/stdint.h"
 
   # Install the build and runtime dependencies of the project.
-  # The --pre flag is necessary to grab a SciPy wheel, which is in
-  # pre-release at the time of writing (03-10-2017)
-  - pip install --retries 3 --pre -r requirements.txt
   - pip install --retries 3 -r requirements/build.txt
+  # scipy, from default is required to build until #3158 is fixed.
+  - pip install --retries 3 -r requirements/default.txt
   - python setup.py bdist_wheel bdist_wininst
   - ps: "ls dist"
 
   # Install the generated wheel package to test it
-  - "pip install --pre --no-index --find-links dist/ scikit-image"
+  - "pip install --no-index --find-links dist/ scikit-image"
+  # Install the test dependencies
+  - pip install --retries 3 -r requirements/test.txt
 
 # Not a .NET project, we build scikit-image in the install step instead
 build: false

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,6 +11,8 @@ environment:
 
 matrix:
   fast_finish: true
+  allow_failures:
+    - PIP_FLAGS: --pre
 
 install:
   - ECHO "Filesystem root:"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,6 +6,8 @@ environment:
     - PYTHON: C:\Python35-x64
     - PYTHON: C:\Python36
     - PYTHON: C:\Python36-x64
+    - PYTHON: C:\Python36-x64
+      PIP_FLAGS: --pre
 
 matrix:
   fast_finish: true
@@ -37,16 +39,16 @@ install:
   - "curl https://raw.githubusercontent.com/chemeris/msinttypes/master/stdint.h -o skimage/external/tifffile/stdint.h"
 
   # Install the build and runtime dependencies of the project.
-  - pip install --retries 3 -r requirements/build.txt
+  - pip install %PIP_FLAGS% --retries 3 -r requirements/build.txt
   # scipy, from default is required to build until #3158 is fixed.
-  - pip install --retries 3 -r requirements/default.txt
+  - pip install %PIP_FLAGS% --retries 3 -r requirements/default.txt
   - python setup.py bdist_wheel bdist_wininst
   - ps: "ls dist"
 
   # Install the generated wheel package to test it
-  - "pip install --no-index --find-links dist/ scikit-image"
+  - pip install %PIP_FLAGS% --no-index --find-links dist/ scikit-image
   # Install the test dependencies
-  - pip install --retries 3 -r requirements/test.txt
+  - pip install %PIP_FLAGS% --retries 3 -r requirements/test.txt
 
 # Not a .NET project, we build scikit-image in the install step instead
 build: false


### PR DESCRIPTION
This is an example of what a PR would look like if we allow failures on Appveyor

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
