### PR TITLE
Travis allow failrues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,8 @@ matrix:
       language: objective-c
       # OS X has a hard time installing the docs dependencies
       env: TRAVIS_PYTHON_VERSION=3.5
+  allow_failures:
+    - env: QT=PyQt5 WITH_PYAMG=1 OPTIONAL_DEPS=1 PIP_FLAGS="--pre"
 
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then


### PR DESCRIPTION
This is an example of a travis build would look like if we allow failures on `--pre`

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
